### PR TITLE
Fix Env/Modulecmd.pm when modulecmd v4+ is used

### DIFF
--- a/lib/Env/Modulecmd.pm
+++ b/lib/Env/Modulecmd.pm
@@ -208,6 +208,9 @@ sub _modulecmd {
     # case, eval will die, with a message indicating what went wrong.
     # we want to catch this and nicely print out the error.
 
+    # $_mlstatus is a variable dumped by modulecmd without 'my'.
+    # See https://github.com/cea-hpc/modules/pull/314 for details.
+    my $_mlstatus = 0;
     eval $out;
 
     croak


### PR DESCRIPTION
New version (checked with `v4.1.4` on RH8.1) of `modulecmd` always dump a variable with the status if anything was rendered. Since it is dumped without `my`, `eval`'ing it in a strict scope fails. I've addressed that with [PR](https://github.com/cea-hpc/modules/pull/314), but guess this variable can be ignored by MTT.